### PR TITLE
Feat/12-refresh-token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     //Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 
     // S3
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'

--- a/src/main/java/com/aminspire/domain/user/service/SocialLoginService.java
+++ b/src/main/java/com/aminspire/domain/user/service/SocialLoginService.java
@@ -10,6 +10,7 @@ import com.aminspire.global.security.jwt.JwtProvider;
 import com.aminspire.global.security.oauht2.google.GoogleClient;
 import com.aminspire.global.security.oauht2.google.dto.GoogleProfile;
 import com.aminspire.global.security.oauht2.google.dto.GoogleToken;
+import com.aminspire.infra.config.redis.RedisClient;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/aminspire/global/exception/errorcode/RedisErrorCode.java
+++ b/src/main/java/com/aminspire/global/exception/errorcode/RedisErrorCode.java
@@ -1,0 +1,20 @@
+package com.aminspire.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RedisErrorCode implements BaseErrorCode{
+
+    REDIS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 설정에 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCodeName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/aminspire/infra/config/redis/RedisClient.java
+++ b/src/main/java/com/aminspire/infra/config/redis/RedisClient.java
@@ -1,0 +1,54 @@
+package com.aminspire.infra.config.redis;
+
+import com.aminspire.global.exception.CommonException;
+import com.aminspire.global.exception.errorcode.RedisErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisClient {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValue(String key, String value, Long timeout) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            values.set(key, value, Duration.ofMillis(timeout));
+        } catch (Exception e) {
+            throw new CommonException(RedisErrorCode.REDIS_ERROR);
+        }
+    }
+
+    public String getValue(String key) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            if (values.get(key) == null) {
+                return "";
+            }
+            return values.get(key).toString();
+        } catch (Exception e) {
+            throw new CommonException(RedisErrorCode.REDIS_ERROR);
+        }
+    }
+
+    public void deleteValue(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            throw new CommonException(RedisErrorCode.REDIS_ERROR);
+        }
+    }
+
+    public boolean checkExistsValue(String key) {
+        try {
+            return redisTemplate.hasKey(key);
+        } catch (Exception e) {
+            throw new CommonException(RedisErrorCode.REDIS_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/aminspire/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/aminspire/infra/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.aminspire.infra.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
- 로그인 성공 시 엑세스 토큰과 함께 리프레시 토큰을 발급하도록 구현하였습니다.
- 발급한 리프레시 토큰은 응답 쿠키에 저장되며, 추가적으로 Redis에 저장되도록 관련 설정을 추가했습니다.