### PR TITLE
#21 feat: 리프레시 토큰으로 엑세스 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/com/aminspire/domain/user/controller/AuthController.java
+++ b/src/main/java/com/aminspire/domain/user/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.aminspire.domain.user.controller;
 
 import com.aminspire.domain.user.dto.response.LoginResponse;
+import com.aminspire.domain.user.dto.response.TokenResponse;
+import com.aminspire.domain.user.service.AuthService;
 import com.aminspire.domain.user.service.SocialLoginService;
-import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.security.AuthDetails;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final SocialLoginService socialLoginService;
+    private final AuthService authService;
 
     @PostMapping("/google/sign-in")
     public LoginResponse signInWithGoogle(@RequestParam("code") String code, HttpServletResponse response) {
@@ -27,5 +32,10 @@ public class AuthController {
     @PostMapping("/kakao/sign-in")
     public LoginResponse signInWithKakao(@RequestParam("code") String code, HttpServletResponse response) {
         return socialLoginService.signInWithKakao(code, response);
+    }
+
+    @PostMapping("/reissue")
+    public TokenResponse reissue(HttpServletRequest request, HttpServletResponse response) {
+        return authService.recreate(request, response);
     }
 }

--- a/src/main/java/com/aminspire/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/com/aminspire/domain/user/dto/response/TokenResponse.java
@@ -1,0 +1,19 @@
+package com.aminspire.domain.user.dto.response;
+
+import lombok.Builder;
+
+public record TokenResponse(
+        String message
+) {
+
+    public static TokenResponse of(String message) {
+        return TokenResponse.builder()
+                .message(message)
+                .build();
+    }
+
+    @Builder
+    public TokenResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/aminspire/domain/user/service/AuthService.java
+++ b/src/main/java/com/aminspire/domain/user/service/AuthService.java
@@ -1,0 +1,43 @@
+package com.aminspire.domain.user.service;
+
+import com.aminspire.domain.user.domain.user.User;
+import com.aminspire.domain.user.dto.response.TokenResponse;
+import com.aminspire.global.exception.CommonException;
+import com.aminspire.global.exception.errorcode.JwtErrorCode;
+import com.aminspire.global.exception.errorcode.UserErrorCode;
+import com.aminspire.global.security.jwt.JwtProvider;
+import com.aminspire.infra.config.redis.RedisClient;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final RedisClient redisClient;
+
+    public TokenResponse recreate(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = jwtProvider.getRefreshTokenFromCookie(request);
+        boolean isValid = jwtProvider.validateToken(refreshToken, "refresh");
+
+        if (!isValid) {
+            throw new CommonException(JwtErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        String email = jwtProvider.getEmail(refreshToken);
+        String redisRefreshToken = redisClient.getValue(email);
+
+        if (StringUtils.isEmpty(refreshToken) || StringUtils.isEmpty(redisRefreshToken) || !redisRefreshToken.equals(refreshToken)) {
+            throw new CommonException(JwtErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        jwtProvider.recreate(refreshToken, response);
+
+        return TokenResponse.of("엑세스 토큰 재발급 성공");
+    }
+}

--- a/src/main/java/com/aminspire/global/config/SecurityConfig.java
+++ b/src/main/java/com/aminspire/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers( "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**").permitAll()
                         .requestMatchers("/auth/google/sign-in").permitAll()
+                        .requestMatchers("/auth/reissue").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
+++ b/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
@@ -1,0 +1,20 @@
+package com.aminspire.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode implements BaseErrorCode{
+
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유호하지 않은 리프레시 토큰입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCodeName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/aminspire/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/aminspire/global/security/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.aminspire.global.security.jwt;
 
+import com.aminspire.domain.user.domain.user.Role;
 import com.aminspire.domain.user.domain.user.User;
 import com.aminspire.infra.config.redis.RedisClient;
 import io.jsonwebtoken.Claims;
@@ -9,6 +10,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -74,6 +77,41 @@ public class JwtProvider {
         redisClient.setValue(user.getEmail(), refreshToken, 1000 * 60 * 60 * 24 * 7L); // Redis에 저장
     }
 
+    public void recreate(String refreshToken, HttpServletResponse response) {
+        String email = getEmail(refreshToken);
+        String role = getRole(refreshToken);
+
+        String accessToken = recreateAccessToken(email, role);
+        response.setHeader("accessToken", accessToken);
+
+        refreshToken = recreateRefreshToken(email, role);
+        response.addHeader(HttpHeaders.SET_COOKIE, createResponseCookie("refreshToken", refreshToken).toString());
+
+        redisClient.setValue(email, refreshToken, 1000 * 60 * 60 * 24 * 7L);
+    }
+
+    public String recreateAccessToken(String email, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String recreateRefreshToken(String email, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     public ResponseCookie createResponseCookie(String key, String value) {
 
         return ResponseCookie.from(key, value)
@@ -102,7 +140,32 @@ public class JwtProvider {
         }
     }
 
+    // 쿠키로부터 리프레시 토큰 추출
+    public String getRefreshTokenFromCookie(HttpServletRequest request) {
+
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+
+                if (cookie.getName().equals("refreshToken")) {
+                    refreshToken = cookie.getValue();
+                }
+            }
+        }
+
+        return refreshToken;
+    }
+
     public String getEmail(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String getRole(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("role", String.class);
+    }
+
+    public Long getExpirationTime(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().getTime();
     }
 }


### PR DESCRIPTION
- 리프레시 토큰으로 엑세스 토큰 재발급 로직을 구현하였습니다.
- 시큐리티 필터 내부 예외 처리 로직은 아직 구현하지 않았습니다.
- 이슈 생성해서 전체적인 예외 처리 구현하겠습니다!