### PR TITLE
#36 feat: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/aminspire/domain/user/controller/AuthController.java
+++ b/src/main/java/com/aminspire/domain/user/controller/AuthController.java
@@ -38,4 +38,9 @@ public class AuthController {
     public TokenResponse reissue(HttpServletRequest request, HttpServletResponse response) {
         return authService.recreate(request, response);
     }
+
+    @PostMapping("/sign-out")
+    public TokenResponse signOut(HttpServletRequest request, HttpServletResponse response) {
+        return authService.signOut(request, response);
+    }
 }

--- a/src/main/java/com/aminspire/global/config/SecurityConfig.java
+++ b/src/main/java/com/aminspire/global/config/SecurityConfig.java
@@ -36,8 +36,8 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers( "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**").permitAll()
-                        .requestMatchers("/auth/google/sign-in").permitAll()
-                        .requestMatchers("/auth/reissue").authenticated()
+                        .requestMatchers("/auth/google/sign-in", "auth/kakao/sign-in", "/auth/reissue").permitAll()
+                        .requestMatchers("/auth/sign-out").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
+++ b/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum JwtErrorCode implements BaseErrorCode{
 
-    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유호하지 않은 리프레시 토큰입니다.");
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유호하지 않은 리프레시 토큰입니다."),
+    ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT 토큰이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/aminspire/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/aminspire/global/security/jwt/JwtFilter.java
@@ -27,7 +27,7 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String token = getTokenFromRequest(request);
+        String token = jwtProvider.getAccessTokenFromRequest(request);
 
         if (StringUtils.hasText(token) && jwtProvider.validateToken(token, "access")) {
             String email = jwtProvider.getEmail(token);
@@ -42,13 +42,5 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String getTokenFromRequest(HttpServletRequest request) {
-        String token = request.getHeader("Authorization");
-        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
-            return token.substring(7);
-        }
-        return null;
     }
 }

--- a/src/main/java/com/aminspire/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/aminspire/global/security/jwt/JwtProvider.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -139,6 +140,15 @@ public class JwtProvider {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    // 헤더로부터 엑세스 토큰 추출
+    public String getAccessTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
     }
 
     // 쿠키로부터 리프레시 토큰 추출


### PR DESCRIPTION
- 구글, 카카오 로그인 사용자 로그아웃 기능을 구현하였습니다.
- 로그아웃 성공 시 쿠키 및 레디스에 저장되어 있는 리프레시 토큰을 삭제하도록 구성하였습니다.
- 엑세스 토큰은 프론트 로컬 스토리지에서 삭제하는 것으로 로그아웃 로직을 구현하면 될 것 같습니다!