### PR TITLE
Feat/44 error handling

### DIFF
--- a/src/main/java/com/aminspire/domain/user/domain/user/User.java
+++ b/src/main/java/com/aminspire/domain/user/domain/user/User.java
@@ -38,7 +38,7 @@ public class User extends BaseTimeEntity {
     private LoginType loginType;
 
     @Builder
-    public User(String email, String name, Role role, LoginType loginType, String socialId) {
+    public User(String email, String name, Role role, LoginType loginType) {
         this.email = email;
         this.name = name;
         this.role = role;

--- a/src/main/java/com/aminspire/global/config/SecurityConfig.java
+++ b/src/main/java/com/aminspire/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.aminspire.global.config;
 
+import com.aminspire.global.security.exception.CustomAccessDeniedHandler;
+import com.aminspire.global.security.exception.CustomAuthenticationEntryPoint;
 import com.aminspire.global.security.exception.ExceptionFilter;
 import com.aminspire.global.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,8 @@ public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
     private final ExceptionFilter exceptionFilter;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -35,6 +39,12 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(
                                 SessionCreationPolicy.STATELESS)); // Session 미사용
         http.httpBasic(AbstractHttpConfigurer::disable).formLogin(AbstractHttpConfigurer::disable);
+
+        http.exceptionHandling((exceptionHandling) ->
+                exceptionHandling
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+        ); // 에러 핸들러 등록
 
         http.authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers( "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**").permitAll()

--- a/src/main/java/com/aminspire/global/config/SecurityConfig.java
+++ b/src/main/java/com/aminspire/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.aminspire.global.config;
 
+import com.aminspire.global.security.exception.ExceptionFilter;
 import com.aminspire.global.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +24,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    private final ExceptionFilter exceptionFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -40,7 +42,8 @@ public class SecurityConfig {
                         .requestMatchers("/auth/sign-out", "auth/cancel").authenticated()
                         .requestMatchers("/user/**").authenticated()
                         .anyRequest().permitAll())
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionFilter, JwtFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
+++ b/src/main/java/com/aminspire/global/exception/errorcode/JwtErrorCode.java
@@ -10,7 +10,9 @@ public enum JwtErrorCode implements BaseErrorCode{
 
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유호하지 않은 리프레시 토큰입니다."),
     ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT 토큰이 존재하지 않습니다.");
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT 토큰이 존재하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패했습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/aminspire/global/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/aminspire/global/security/exception/CustomAccessDeniedHandler.java
@@ -1,6 +1,7 @@
 package com.aminspire.global.security.exception;
 
 import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.exception.ErrorMsg;
 import com.aminspire.global.exception.errorcode.JwtErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,8 +25,12 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(JwtErrorCode.FORBIDDEN.getHttpStatus().value());
 
-        CommonResponse<String> errorResponse = CommonResponse.onFailure(
-                JwtErrorCode.FORBIDDEN.getHttpStatus().value(), JwtErrorCode.FORBIDDEN.getMessage());
+        CommonResponse<ErrorMsg> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.FORBIDDEN.getHttpStatus().value(),
+                ErrorMsg.builder()
+                        .code(JwtErrorCode.FORBIDDEN.getCodeName())
+                        .reason(JwtErrorCode.FORBIDDEN.getMessage())
+                        .build());
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(errorJson);

--- a/src/main/java/com/aminspire/global/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/aminspire/global/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.aminspire.global.security.exception;
+
+import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.exception.errorcode.JwtErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(JwtErrorCode.FORBIDDEN.getHttpStatus().value());
+
+        CommonResponse<String> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.FORBIDDEN.getHttpStatus().value(), JwtErrorCode.FORBIDDEN.getMessage());
+        String errorJson = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(errorJson);
+    }
+}

--- a/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.aminspire.global.security.exception;
+
+import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.exception.errorcode.JwtErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(JwtErrorCode.UNAUTHORIZED.getHttpStatus().value());
+
+        CommonResponse<String> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(), JwtErrorCode.UNAUTHORIZED.getMessage());
+        String errorJson = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(errorJson);
+    }
+}

--- a/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -23,13 +23,13 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
 
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(JwtErrorCode.UNAUTHORIZED.getHttpStatus().value());
+        response.setStatus(JwtErrorCode.FORBIDDEN.getHttpStatus().value());
 
         CommonResponse<ErrorMsg> errorResponse = CommonResponse.onFailure(
-                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(),
+                JwtErrorCode.FORBIDDEN.getHttpStatus().value(),
                 ErrorMsg.builder()
-                        .code(JwtErrorCode.UNAUTHORIZED.getCodeName())
-                        .reason(JwtErrorCode.UNAUTHORIZED.getMessage())
+                        .code(JwtErrorCode.FORBIDDEN.getCodeName())
+                        .reason(JwtErrorCode.FORBIDDEN.getMessage())
                         .build());
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 

--- a/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/aminspire/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.aminspire.global.security.exception;
 
 import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.exception.ErrorMsg;
 import com.aminspire.global.exception.errorcode.JwtErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,8 +25,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(JwtErrorCode.UNAUTHORIZED.getHttpStatus().value());
 
-        CommonResponse<String> errorResponse = CommonResponse.onFailure(
-                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(), JwtErrorCode.UNAUTHORIZED.getMessage());
+        CommonResponse<ErrorMsg> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(),
+                ErrorMsg.builder()
+                        .code(JwtErrorCode.UNAUTHORIZED.getCodeName())
+                        .reason(JwtErrorCode.UNAUTHORIZED.getMessage())
+                        .build());
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(errorJson);

--- a/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
+++ b/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
@@ -1,0 +1,44 @@
+package com.aminspire.global.security.exception;
+
+import com.aminspire.global.common.response.CommonResponse;
+import com.aminspire.global.exception.CommonException;
+import com.aminspire.global.exception.ErrorMsg;
+import com.aminspire.global.exception.ErrorResponse;
+import com.aminspire.global.exception.errorcode.JwtErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class ExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CommonException e) {
+            setResponse(response);
+        }
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException{
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(JwtErrorCode.ACCESS_TOKEN_INVALID.getHttpStatus().value());
+
+        CommonResponse<String> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.ACCESS_TOKEN_INVALID.getHttpStatus().value(), JwtErrorCode.ACCESS_TOKEN_INVALID.getMessage());
+        String errorJson = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(errorJson);
+    }
+}

--- a/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
+++ b/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
@@ -5,6 +5,8 @@ import com.aminspire.global.exception.CommonException;
 import com.aminspire.global.exception.ErrorMsg;
 import com.aminspire.global.exception.ErrorResponse;
 import com.aminspire.global.exception.errorcode.JwtErrorCode;
+import com.aminspire.global.security.jwt.JwtFilter;
+import com.aminspire.global.security.jwt.JwtFilter.TokenInValidateException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -27,18 +29,18 @@ public class ExceptionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (CommonException e) {
-            setResponse(response);
+        } catch (TokenInValidateException e) {
+            setResponse(response, e);
         }
     }
 
-    private void setResponse(HttpServletResponse response) throws IOException{
+    private void setResponse(HttpServletResponse response, Throwable e) throws IOException{
 
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(JwtErrorCode.ACCESS_TOKEN_INVALID.getHttpStatus().value());
+        response.setStatus(JwtErrorCode.UNAUTHORIZED.getHttpStatus().value());
 
         CommonResponse<String> errorResponse = CommonResponse.onFailure(
-                JwtErrorCode.ACCESS_TOKEN_INVALID.getHttpStatus().value(), JwtErrorCode.ACCESS_TOKEN_INVALID.getMessage());
+                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(), e.getMessage());
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(errorJson);

--- a/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
+++ b/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 public class ExceptionFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
+
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
@@ -32,6 +33,7 @@ public class ExceptionFilter extends OncePerRequestFilter {
     }
 
     private void setResponse(HttpServletResponse response) throws IOException{
+
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(JwtErrorCode.ACCESS_TOKEN_INVALID.getHttpStatus().value());
 

--- a/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
+++ b/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
@@ -1,11 +1,8 @@
 package com.aminspire.global.security.exception;
 
 import com.aminspire.global.common.response.CommonResponse;
-import com.aminspire.global.exception.CommonException;
 import com.aminspire.global.exception.ErrorMsg;
-import com.aminspire.global.exception.ErrorResponse;
 import com.aminspire.global.exception.errorcode.JwtErrorCode;
-import com.aminspire.global.security.jwt.JwtFilter;
 import com.aminspire.global.security.jwt.JwtFilter.TokenInValidateException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;

--- a/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
+++ b/src/main/java/com/aminspire/global/security/exception/ExceptionFilter.java
@@ -39,8 +39,12 @@ public class ExceptionFilter extends OncePerRequestFilter {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(JwtErrorCode.UNAUTHORIZED.getHttpStatus().value());
 
-        CommonResponse<String> errorResponse = CommonResponse.onFailure(
-                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(), e.getMessage());
+        CommonResponse<ErrorMsg> errorResponse = CommonResponse.onFailure(
+                JwtErrorCode.UNAUTHORIZED.getHttpStatus().value(),
+                ErrorMsg.builder()
+                        .code(JwtErrorCode.UNAUTHORIZED.getCodeName())
+                        .reason(e.getMessage())
+                        .build());
         String errorJson = objectMapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(errorJson);

--- a/src/main/java/com/aminspire/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/aminspire/global/security/jwt/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.aminspire.global.security.jwt;
 
 import com.aminspire.global.security.AuthDetailsService;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,5 +43,16 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    public static class TokenInValidateException extends JwtException {
+
+        public TokenInValidateException(String message) {
+            super(message);
+        }
+
+        public TokenInValidateException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 }


### PR DESCRIPTION
- CustomAuthenticationEntryPoint는 인증 예외를 처리합니다.
  인증되지 않은 사용자가 인증이 필요한 API에 접근할 경우 403 에러를 반환합니다.
- CustomAccessDeniedHandler는 인가 예외를 처리합니다.
  인증이 완료된 사용자가 접근 권한(Role)이 없는 API에 접근할 경우 403 에러를 반환합니다.
- ExceptionFilter는 JwtFilter 내부 예외를 처리합니다.
  만료된 JWT 토큰 등 JwtFilter 내부 로직에서 발생한 예외를 체크하여 401 에러를 반환합니다. 